### PR TITLE
Feature/tb 3 user friendly errors

### DIFF
--- a/docs/googleaa61ad26785f058a.html
+++ b/docs/googleaa61ad26785f058a.html
@@ -1,0 +1,1 @@
+google-site-verification: googleaa61ad26785f058a.html

--- a/projects/ngx-testbox/package.json
+++ b/projects/ngx-testbox/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ngx-testbox",
   "description": "Comprehensive testing utilities that simplifies writing and maintaining tests",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "author": {
     "email": "kkolomin.w@gmail.com",
     "name": "Kirill Kolomin"

--- a/projects/ngx-testbox/src/__tests__/complete-http-calls.spec.ts
+++ b/projects/ngx-testbox/src/__tests__/complete-http-calls.spec.ts
@@ -9,6 +9,9 @@ import {
   getRequestsFromQueue,
   HttpCallInstruction
 } from '../../testing/src/complete-http-calls';
+import {
+  NoMatchingHttpInstructionForRequestFoundError
+} from '../../testing/src/errors/NoMatchingHttpInstructionForRequestFoundError';
 
 describe('completeHttpCalls', () => {
   let httpClient: HttpClient;
@@ -133,7 +136,7 @@ describe('completeHttpCalls', () => {
       ];
 
       expect(() => completeHttpCalls(instructions))
-        .toThrowError(`No matching HTTP instruction found for request with URL "/api/test" and method "GET". Please ensure you've provided the correct HTTP call instructions for all expected requests.`);
+        .toThrowError(NoMatchingHttpInstructionForRequestFoundError);
     });
 
     it('should skip cancelled requests', () => {

--- a/projects/ngx-testbox/src/__tests__/complete-http-calls.spec.ts
+++ b/projects/ngx-testbox/src/__tests__/complete-http-calls.spec.ts
@@ -133,7 +133,7 @@ describe('completeHttpCalls', () => {
       ];
 
       expect(() => completeHttpCalls(instructions))
-        .toThrowError(/There is not a defined http instruction for request with url "\/api\/test" and method "GET"/);
+        .toThrowError(`No matching HTTP instruction found for request with URL "/api/test" and method "GET". Please ensure you've provided the correct HTTP call instructions for all expected requests.`);
     });
 
     it('should skip cancelled requests', () => {

--- a/projects/ngx-testbox/src/__tests__/debug-element-harness.spec.ts
+++ b/projects/ngx-testbox/src/__tests__/debug-element-harness.spec.ts
@@ -153,8 +153,8 @@ describe('DebugElementHarness', () => {
         ['nonexistent'] as const
       );
 
-      const textContent = nonExistentHarness.elements.nonexistent.getTextContent();
-      expect(textContent).toBeUndefined();
+      const cb = () => nonExistentHarness.elements.nonexistent.getTextContent();
+      expect(cb).toThrow();
     });
   });
 });

--- a/projects/ngx-testbox/src/__tests__/debug-element-harness.spec.ts
+++ b/projects/ngx-testbox/src/__tests__/debug-element-harness.spec.ts
@@ -3,6 +3,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { DebugElementHarness } from '../../testing/src/debug-element-harness';
 import createSpy = jasmine.createSpy;
+import {NoElementByTestIdFoundError} from '../../testing/src/errors/NoElementByTestIdFoundError';
 
 @Component({
   template: `
@@ -128,6 +129,15 @@ describe('DebugElementHarness', () => {
 
       expect(spy).toHaveBeenCalled();
     });
+
+    it('should throw if element is not found', () => {
+      const nonExistentHarness = new DebugElementHarness(
+        debugElement,
+        ['nonexistent'] as const
+      );
+
+      expect(() => nonExistentHarness.elements.nonexistent.click()).toThrowError(NoElementByTestIdFoundError);
+    });
   });
 
   describe('focus', () => {
@@ -139,6 +149,15 @@ describe('DebugElementHarness', () => {
 
       expect(inputElement.nativeElement.focus).toHaveBeenCalled();
     });
+
+    it('should throw if element is not found', () => {
+      const nonExistentHarness = new DebugElementHarness(
+        debugElement,
+        ['nonexistent'] as const
+      );
+
+      expect(() => nonExistentHarness.elements.nonexistent.focus()).toThrowError(NoElementByTestIdFoundError);
+    });
   });
 
   describe('getTextContent', () => {
@@ -147,14 +166,13 @@ describe('DebugElementHarness', () => {
       expect(textContent).toBe('Some text content');
     });
 
-    it('should return undefined if element is not found', () => {
+    it('should throw if element is not found', () => {
       const nonExistentHarness = new DebugElementHarness(
         debugElement,
         ['nonexistent'] as const
       );
 
-      const cb = () => nonExistentHarness.elements.nonexistent.getTextContent();
-      expect(cb).toThrow();
+      expect(() => nonExistentHarness.elements.nonexistent.getTextContent()).toThrowError(NoElementByTestIdFoundError);
     });
   });
 });

--- a/projects/ngx-testbox/src/__tests__/run-tasks-until-stable.spec.ts
+++ b/projects/ngx-testbox/src/__tests__/run-tasks-until-stable.spec.ts
@@ -3,7 +3,7 @@ import {ComponentFixture, fakeAsync, TestBed} from '@angular/core/testing';
 import {HttpTestingController, provideHttpClientTesting} from '@angular/common/http/testing';
 import {HttpClient, HttpResponse, provideHttpClient} from '@angular/common/http';
 import {runTasksUntilStable,} from '../../testing/src/run-tasks-until-stable';
-import {HttpCallInstruction} from 'ngx-testbox/testing';
+import {HttpCallInstruction} from '../../testing/src/complete-http-calls';
 
 @Component({
   template: '<div>Test Component</div>',

--- a/projects/ngx-testbox/src/__tests__/run-tasks-until-stable.spec.ts
+++ b/projects/ngx-testbox/src/__tests__/run-tasks-until-stable.spec.ts
@@ -4,6 +4,16 @@ import {HttpTestingController, provideHttpClientTesting} from '@angular/common/h
 import {HttpClient, HttpResponse, provideHttpClient} from '@angular/common/http';
 import {runTasksUntilStable,} from '../../testing/src/run-tasks-until-stable';
 import {HttpCallInstruction} from '../../testing/src/complete-http-calls';
+import {
+  NoMatchingHttpInstructionForRequestFoundError
+} from '../../testing/src/errors/NoMatchingHttpInstructionForRequestFoundError';
+import {
+  HttpInstructionWasNotExecutedDuringFixtureStabilizationError
+} from '../../testing/src/errors/HttpInstructionWasNotExecutedDuringFixtureStabilizationError';
+import {
+  MaximumAttemptsToStabilizeFixtureReachedError
+} from '../../testing/src/errors/MaximumAttemptsToStabilizeFixtureReachedError';
+import {FailedToGenerateHttpResponseError} from '../../testing/src/errors/FailedToGenerateHttpResponseError';
 
 @Component({
   template: '<div>Test Component</div>',
@@ -82,7 +92,7 @@ describe('runTasksUntilStable', () => {
       initComponent();
 
       expect(() => runTasksUntilStable(fixture, {httpCallInstructions}))
-        .toThrowError(/There was an http call instruction not called during draining of http requests/);
+        .toThrowError(HttpInstructionWasNotExecutedDuringFixtureStabilizationError);
     }));
 
     it('should throw an error if an HTTP request is not handled', fakeAsync(() => {
@@ -91,7 +101,7 @@ describe('runTasksUntilStable', () => {
       component.makeHttpRequest();
 
       expect(() => runTasksUntilStable(fixture))
-        .toThrowError('There is not a defined http instruction for request with url "/api/test" and method "GET"');
+        .toThrowError(NoMatchingHttpInstructionForRequestFoundError);
     }));
   });
 
@@ -102,20 +112,7 @@ describe('runTasksUntilStable', () => {
 
       fixture.componentRef.setInput('isTestingIntervalWithinZone', true);
 
-      expect(() => runTasksUntilStable(fixture)).toThrowError('Maximum attempts reached. Fixture is not stable.');
-    }));
-
-    it('should catch HttpErrorResponse errors', fakeAsync(() => {
-      const httpCallInstructions: HttpCallInstruction[] = [
-        [['/api/test', 'GET'], () => new HttpResponse({body: {}, status: 200})]
-      ];
-
-      initComponent();
-
-      component.makeHttpRequest();
-      runTasksUntilStable(fixture, {httpCallInstructions});
-
-      expect(() => runTasksUntilStable(fixture, {httpCallInstructions})).toThrowError();
+      expect(() => runTasksUntilStable(fixture)).toThrowError(MaximumAttemptsToStabilizeFixtureReachedError);
     }));
   });
 
@@ -135,7 +132,7 @@ describe('runTasksUntilStable', () => {
       } catch (error) {}
 
       expect(consoleWarnSpy).toHaveBeenCalled();
-      expect(consoleWarnSpy.calls.mostRecent().args[0]).toContain('setInterval might be the potential problem');
+      expect(consoleWarnSpy.calls.mostRecent().args[0]).toContain('setInterval detected during runTasksUntilStable execution');
 
       console.warn = originalConsoleWarn;
     }));

--- a/projects/ngx-testbox/testing/src/complete-http-calls.ts
+++ b/projects/ngx-testbox/testing/src/complete-http-calls.ts
@@ -1,6 +1,8 @@
 import {TestBed} from '@angular/core/testing';
 import {HttpTestingController, TestRequest} from '@angular/common/http/testing';
 import {HttpRequest, HttpResponse} from '@angular/common/http';
+import {FailedToGenerateHttpResponseError} from './errors/FailedToGenerateHttpResponseError';
+import {NoMatchingHttpInstructionForRequestFoundError} from './errors/NoMatchingHttpInstructionForRequestFoundError';
 
 /**
  * Represents an HTTP method (GET, POST, PUT, DELETE, etc.).
@@ -90,7 +92,7 @@ export const completeHttpCalls = (httpCallInstructions: HttpCallInstruction[], {
     })
 
     if (instruction === undefined) {
-      throw new Error(`No matching HTTP instruction found for request with URL "${request.url}" and method "${request.method}". Please ensure you've provided the correct HTTP call instructions for all expected requests.`)
+      throw new NoMatchingHttpInstructionForRequestFoundError(request.url, request.method);
     }
 
     const [_, responseGetter] = instruction;
@@ -100,8 +102,7 @@ export const completeHttpCalls = (httpCallInstructions: HttpCallInstruction[], {
     try {
       response = responseGetter(request, urlSearchParams);
     } catch (error) {
-      console.error('Error in responseGetter function:', error);
-      throw new Error(`Failed to generate HTTP response: ${error instanceof Error ? error.message : 'Unknown error'}. Check your responseGetter function.`);
+      throw new FailedToGenerateHttpResponseError(error);
     }
 
     testRequest.flush(response.body as any, {

--- a/projects/ngx-testbox/testing/src/complete-http-calls.ts
+++ b/projects/ngx-testbox/testing/src/complete-http-calls.ts
@@ -112,24 +112,8 @@ export const completeHttpCalls = (httpCallInstructions: HttpCallInstruction[], {
   }
 }
 
-/**
- * Extracts URL search parameters from a request URL.
- *
- * @param requestUrl - The full URL of the request, including query parameters
- * @returns A URLSearchParams object containing the parsed query parameters
- */
 function extractSearchParams(requestUrl: string): URLSearchParams {
-  if (!requestUrl) {
-    throw new Error('Cannot extract search parameters: Request URL is empty or undefined');
-  }
-
-  const parts = requestUrl.split('?');
-  if (parts.length < 2) {
-    // No query parameters in the URL, return empty URLSearchParams
-    return new URLSearchParams();
-  }
-
-  const queryParams = parts[1];
+  const queryParams = requestUrl.split('?')[1];
   const urlSearchParams = new URLSearchParams(queryParams);
 
   return urlSearchParams;

--- a/projects/ngx-testbox/testing/src/debug-element-harness.ts
+++ b/projects/ngx-testbox/testing/src/debug-element-harness.ts
@@ -4,7 +4,6 @@ import {testAttribute} from './consts/test-attribute';
 
 /**
  * Interface defining the API for interacting with elements in tests.
- * @type
  */
 type ElementApi = {
   /**
@@ -95,38 +94,14 @@ export class DebugElementHarness<TestIds extends readonly string[]> {
     }, {} as Record<TestIds[number], ElementApi>)
   }
 
-  /**
-   * Queries for an element with the specified test ID.
-   *
-   * @param testId - The test ID to search for.
-   * @param parentDebugElement - Optional parent debug element to search within.
-   * @returns The found debug element.
-   * @private
-   */
   #query(testId: TestIds[number], parentDebugElement?: DebugElement): DebugElement {
     return (parentDebugElement || this.debugElement).query(By.css(`[${this.testIdAttribute}="${testId}"]`));
   }
 
-  /**
-   * Queries for all elements with the specified test ID.
-   *
-   * @param testId - The test ID to search for.
-   * @param parentDebugElement - Optional parent debug element to search within.
-   * @returns An array of found debug elements.
-   * @private
-   */
   #queryAll(testId: TestIds[number], parentDebugElement?: DebugElement): DebugElement[] {
     return (parentDebugElement || this.debugElement).queryAll(By.css(`[${this.testIdAttribute}="${testId}"]`));
   }
 
-  /**
-   * Clicks on an element with the specified test ID.
-   *
-   * @param testId - The test ID of the element to click.
-   * @param parentDebugElement - Optional parent debug element to search within.
-   * @throws Error if the element with the specified test ID is not found.
-   * @private
-   */
   #clickOnElement(testId: TestIds[number], parentDebugElement?: DebugElement): void {
     const element = this.#query(testId, parentDebugElement);
 
@@ -137,14 +112,6 @@ export class DebugElementHarness<TestIds extends readonly string[]> {
     element.nativeElement.click();
   }
 
-  /**
-   * Focuses on an element with the specified test ID.
-   *
-   * @param testId - The test ID of the element to focus.
-   * @param parentDebugElement - Optional parent debug element to search within.
-   * @throws Error if the element with the specified test ID is not found.
-   * @private
-   */
   #focusOnElement(testId: TestIds[number], parentDebugElement?: DebugElement): void {
     const element = this.#query(testId, parentDebugElement);
 
@@ -155,15 +122,6 @@ export class DebugElementHarness<TestIds extends readonly string[]> {
     element.nativeElement.focus();
   }
 
-  /**
-   * Gets the text content of an element with the specified test ID.
-   *
-   * @param testId - The test ID of the element to get text content from.
-   * @param parentDebugElement - Optional parent debug element to search within.
-   * @returns The text content of the element.
-   * @throws Error if the element with the specified test ID is not found.
-   * @private
-   */
   #getTextContent(testId: TestIds[number], parentDebugElement?: DebugElement): string {
     const element = this.#query(testId, parentDebugElement);
 

--- a/projects/ngx-testbox/testing/src/debug-element-harness.ts
+++ b/projects/ngx-testbox/testing/src/debug-element-harness.ts
@@ -1,6 +1,7 @@
 import {DebugElement} from '@angular/core';
 import {By} from '@angular/platform-browser';
 import {testAttribute} from './consts/test-attribute';
+import {NoElementByTestIdFoundError} from './errors/NoElementByTestIdFoundError';
 
 /**
  * Interface defining the API for interacting with elements in tests.
@@ -106,7 +107,7 @@ export class DebugElementHarness<TestIds extends readonly string[]> {
     const element = this.#query(testId, parentDebugElement);
 
     if (!element) {
-      throw new Error(`Element with test ID "${testId}" not found`);
+      throw new NoElementByTestIdFoundError(testId);
     }
 
     element.nativeElement.click();
@@ -116,7 +117,7 @@ export class DebugElementHarness<TestIds extends readonly string[]> {
     const element = this.#query(testId, parentDebugElement);
 
     if (!element) {
-      throw new Error(`Element with test ID "${testId}" not found`);
+      throw new NoElementByTestIdFoundError(testId);
     }
 
     element.nativeElement.focus();
@@ -126,7 +127,7 @@ export class DebugElementHarness<TestIds extends readonly string[]> {
     const element = this.#query(testId, parentDebugElement);
 
     if (!element) {
-      throw new Error(`Element with test ID "${testId}" not found`);
+      throw new NoElementByTestIdFoundError(testId);
     }
 
     return element.nativeElement.textContent;

--- a/projects/ngx-testbox/testing/src/errors/FailedToGenerateHttpResponseError.ts
+++ b/projects/ngx-testbox/testing/src/errors/FailedToGenerateHttpResponseError.ts
@@ -1,0 +1,5 @@
+export class FailedToGenerateHttpResponseError extends Error {
+  constructor(genuineError: any) {
+    super(`Check your responseGetter function. Failed to generate HTTP response: ${genuineError instanceof Error ? genuineError.message : 'Unknown error'}.`);
+  }
+}

--- a/projects/ngx-testbox/testing/src/errors/HttpInstructionWasNotExecutedDuringFixtureStabilizationError.ts
+++ b/projects/ngx-testbox/testing/src/errors/HttpInstructionWasNotExecutedDuringFixtureStabilizationError.ts
@@ -1,0 +1,12 @@
+export class HttpInstructionWasNotExecutedDuringFixtureStabilizationError extends Error {
+  constructor(index: number, instruction: string) {
+    super(
+      `An HTTP call instruction was not executed during test stabilization at index ${index}.
+      This may indicate that the expected HTTP request was never made by your component,
+      or that the request was made with different parameters than expected.
+      Check that your component is correctly triggering this HTTP request and that
+      the URL and method in your test instructions match what your component is requesting.
+      The http instruction is -> ${instruction}`
+    );
+  }
+}

--- a/projects/ngx-testbox/testing/src/errors/MaximumAttemptsToStabilizeFixtureReachedError.ts
+++ b/projects/ngx-testbox/testing/src/errors/MaximumAttemptsToStabilizeFixtureReachedError.ts
@@ -1,0 +1,9 @@
+export class MaximumAttemptsToStabilizeFixtureReachedError extends Error {
+  constructor(maximumAttempts: number) {
+    super(
+      `Maximum stabilization attempts (${maximumAttempts}) reached. The fixture could not be stabilized.
+      This may be caused by continuous asynchronous operations like setInterval, or other ongoing processes.
+      Check for setInterval calls in your component and consider mocking them or running them outside Angular zone.`
+    );
+  }
+}

--- a/projects/ngx-testbox/testing/src/errors/NoElementByTestIdFoundError.ts
+++ b/projects/ngx-testbox/testing/src/errors/NoElementByTestIdFoundError.ts
@@ -1,0 +1,5 @@
+export class NoElementByTestIdFoundError extends Error {
+  constructor(testId: string) {
+    super(`Element with test ID "${testId}" not found`);
+  }
+}

--- a/projects/ngx-testbox/testing/src/errors/NoMatchingHttpInstructionForRequestFoundError.ts
+++ b/projects/ngx-testbox/testing/src/errors/NoMatchingHttpInstructionForRequestFoundError.ts
@@ -1,0 +1,5 @@
+export class NoMatchingHttpInstructionForRequestFoundError extends Error {
+  constructor(requestUrl: string, requestMethod: string) {
+    super(`No matching HTTP instruction found for request with URL "${requestUrl}" and method "${requestMethod}". Please ensure you've provided the correct HTTP call instructions for all expected requests.`);
+  }
+}

--- a/projects/ngx-testbox/testing/src/pass-time.ts
+++ b/projects/ngx-testbox/testing/src/pass-time.ts
@@ -25,8 +25,18 @@ export const TIME_MS = 1000;
  * ```
  *
  * @param time - The amount of time in milliseconds to advance (defaults to TIME_MS)
+ * @throws Error if not called within a fakeAsync zone
  */
 export const passTime = (time = TIME_MS): void => {
-  tick(time);
-  flushMicrotasks();
+  try {
+    tick(time);
+    flushMicrotasks();
+  } catch (error) {
+    if (error instanceof Error && error.message.includes('fakeAsync')) {
+      throw new Error(
+        'passTime() can only be called within a fakeAsync zone. Make sure your test is wrapped with fakeAsync().'
+      );
+    }
+    throw error;
+  }
 }

--- a/projects/ngx-testbox/testing/src/pass-time.ts
+++ b/projects/ngx-testbox/testing/src/pass-time.ts
@@ -25,18 +25,8 @@ export const TIME_MS = 1000;
  * ```
  *
  * @param time - The amount of time in milliseconds to advance (defaults to TIME_MS)
- * @throws Error if not called within a fakeAsync zone
  */
 export const passTime = (time = TIME_MS): void => {
-  try {
-    tick(time);
-    flushMicrotasks();
-  } catch (error) {
-    if (error instanceof Error && error.message.includes('fakeAsync')) {
-      throw new Error(
-        'passTime() can only be called within a fakeAsync zone. Make sure your test is wrapped with fakeAsync().'
-      );
-    }
-    throw error;
-  }
+  tick(time);
+  flushMicrotasks();
 }

--- a/projects/ngx-testbox/testing/src/predefined-http-call-instructions.ts
+++ b/projects/ngx-testbox/testing/src/predefined-http-call-instructions.ts
@@ -17,7 +17,14 @@ export const getPredefinedResponseGetter = (status: 'success' | 'error', respons
   const statusText = status === 'success' ? 'OK' : 'Internal Server Error';
 
   return (...args: Parameters<ResponseGetter>) => {
-    const originalResponse = responseGetter?.(...args);
+    let originalResponse: any;
+
+    try {
+      originalResponse = responseGetter?.(...args);
+    } catch (error) {
+      console.error('Error in responseGetter function:', error);
+      throw new Error(`Failed to generate HTTP response: ${error instanceof Error ? error.message : 'Unknown error'}. Check your responseGetter function.`);
+    }
 
     // Check if originalResponse is an HttpResponse
     if (originalResponse instanceof HttpResponse) {

--- a/projects/ngx-testbox/testing/src/predefined-http-call-instructions.ts
+++ b/projects/ngx-testbox/testing/src/predefined-http-call-instructions.ts
@@ -12,7 +12,7 @@ import {HttpResponse} from '@angular/common/http';
  * @param responseGetter - Optional function to generate the response body or a complete HttpResponse
  * @returns A ResponseGetter function that generates HttpResponse objects with the appropriate status
  */
-export const getPredefinedResponseGetter = (status: 'success' | 'error', responseGetter?: (...args: Parameters<ResponseGetter>) => any): ResponseGetter => {
+export const getPredefinedResponseGetter = (status: 'success' | 'error', responseGetter?: (...args: Parameters<ResponseGetter>) => HttpResponse<any> | any): ResponseGetter => {
   const statusCode = status === 'success' ? 200 : 500;
   const statusText = status === 'success' ? 'OK' : 'Internal Server Error';
 
@@ -45,14 +45,7 @@ export const getPredefinedResponseGetter = (status: 'success' | 'error', respons
   };
 }
 
-/**
- * Array of supported HTTP methods for predefined HTTP call instructions.
- */
 export const httpMethods = ['head', 'options', 'get', 'post', 'put', 'patch', 'delete'] as const;
-
-/**
- * Array of supported HTTP status types for predefined HTTP call instructions.
- */
 export const httpStatuses = ['success', 'error'] as const;
 
 /**

--- a/projects/ngx-testbox/testing/src/predefined-http-call-instructions.ts
+++ b/projects/ngx-testbox/testing/src/predefined-http-call-instructions.ts
@@ -1,5 +1,6 @@
 import {EndpointPath, HttpCallInstruction, ResponseGetter} from './complete-http-calls';
 import {HttpResponse} from '@angular/common/http';
+import {FailedToGenerateHttpResponseError} from './errors/FailedToGenerateHttpResponseError';
 
 /**
  * Creates a response getter function that returns HTTP responses with predefined status codes.
@@ -22,8 +23,7 @@ export const getPredefinedResponseGetter = (status: 'success' | 'error', respons
     try {
       originalResponse = responseGetter?.(...args);
     } catch (error) {
-      console.error('Error in responseGetter function:', error);
-      throw new Error(`Failed to generate HTTP response: ${error instanceof Error ? error.message : 'Unknown error'}. Check your responseGetter function.`);
+      throw new FailedToGenerateHttpResponseError(error)
     }
 
     // Check if originalResponse is an HttpResponse

--- a/projects/ngx-testbox/testing/src/run-tasks-until-stable.ts
+++ b/projects/ngx-testbox/testing/src/run-tasks-until-stable.ts
@@ -5,7 +5,7 @@ import {HttpErrorResponse} from '@angular/common/http';
 import {MaximumAttemptsToStabilizeFixtureReachedError} from './errors/MaximumAttemptsToStabilizeFixtureReachedError';
 import {HttpInstructionWasNotExecutedDuringFixtureStabilizationError} from './errors/HttpInstructionWasNotExecutedDuringFixtureStabilizationError';
 
-export const setIntervalDetectedWarning = `Warning: setInterval detected during runTasksUntilStable execution.
+const setIntervalDetectedWarning = `Warning: setInterval detected during runTasksUntilStable execution.
   This may prevent your component from stabilizing and cause "Maximum stabilization attempts reached" errors.
   If the interval causes this kind of issue, to fix it you can:
   1. Mock the code that uses setInterval in your tests

--- a/projects/ngx-testbox/testing/src/run-tasks-until-stable.ts
+++ b/projects/ngx-testbox/testing/src/run-tasks-until-stable.ts
@@ -202,7 +202,7 @@ function patchSetInterval() {
     console.warn(
       'Warning: setInterval detected during runTasksUntilStable execution. ' +
       'This may prevent your component from stabilizing and cause "Maximum stabilization attempts reached" errors. ' +
-      'To fix this issue:\n' +
+      'If the interval causes this kind of issue, to fix it you can:\n' +
       '1. Mock the code that uses setInterval in your tests\n' +
       '2. Run the setInterval code outside Angular zone using NgZone.runOutsideAngular()\n' +
       'Stack trace to help locate the setInterval call:',

--- a/projects/ngx-testbox/testing/src/run-tasks-until-stable.ts
+++ b/projects/ngx-testbox/testing/src/run-tasks-until-stable.ts
@@ -198,15 +198,7 @@ function patchSetInterval() {
   window.setInterval = function setInterval(handler: TimerHandler, timeout?: number, ...args: any[]) {
     const trace = (new Error().stack as string).replace('Error', 'Trace');
 
-    console.warn(
-      'Warning: setInterval detected during runTasksUntilStable execution. ' +
-      'This may prevent your component from stabilizing and cause "Maximum stabilization attempts reached" errors. ' +
-      'If the interval causes this kind of issue, to fix it you can:\n' +
-      '1. Mock the code that uses setInterval in your tests\n' +
-      '2. Run the setInterval code outside Angular zone using NgZone.runOutsideAngular()\n' +
-      'Stack trace to help locate the setInterval call:',
-      trace
-    );
+    console.warn(setIntervalDetectedWarning,trace);
 
     return originalSetInterval(handler, timeout, ...args);
   }


### PR DESCRIPTION
Throw human-readable errors.
Methods focus, click and getTextContent throw errors if an element is not presented in fixture's DOM.
