### PR TITLE
Feature/tb 2 fix http requests tracking for Angular 17>= versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Change Log
+
+[1.2.0] - 2025-09-12
+
+Changed
+* `runTasksUntilStable` - PATCH now always tries to complete all pending HTTP requests, even if HTTP call instructions are not provided.
+* `completeHttpCalls` - MINOR accepts optional field in the options object parameter - `testRequests`.
+
+Fixed
+* `runTasksUntilStable` - PATCH for the Angular version 17th and earlier ones.
+The issue was the fixture is still stable despite pending HTTP requests in the queue.

--- a/projects/ngx-testbox/CHANGELOG.md
+++ b/projects/ngx-testbox/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Change Log
+
+[1.2.0] - 2025-09-12
+
+Changed
+* `runTasksUntilStable` - PATCH now always tries to complete all pending HTTP requests, even if HTTP call instructions are not provided.
+* `completeHttpCalls` - MINOR accepts optional field in the options object parameter - `testRequests`.
+
+Fixed
+* `runTasksUntilStable` - PATCH for the Angular version 17th and earlier ones.
+  The issue was the fixture is still stable despite pending HTTP requests in the queue.

--- a/projects/ngx-testbox/ng-package.json
+++ b/projects/ngx-testbox/ng-package.json
@@ -3,5 +3,6 @@
   "dest": "../../dist/ngx-testbox",
   "lib": {
     "entryFile": "src/lib/public_api.ts"
-  }
+  },
+  "assets": ["CHANGELOG.md"]
 }

--- a/projects/ngx-testbox/package.json
+++ b/projects/ngx-testbox/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ngx-testbox",
   "description": "Integration testing for Angular with black-box approach, async control, and user-centric testing concept.",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "author": {
     "email": "kkolomin.w@gmail.com",
     "name": "Kirill Kolomin"

--- a/projects/ngx-testbox/src/__tests__/pass-time.spec.ts
+++ b/projects/ngx-testbox/src/__tests__/pass-time.spec.ts
@@ -21,9 +21,11 @@ describe('passTime', () => {
         timeoutExecuted = true;
       }, TIME_MS + 100);
 
-      passTime();
+      passTime(TIME_MS);
 
       expect(timeoutExecuted).toBe(false);
+
+      passTime(100)
     }));
 
     it('should advance time by custom amount when parameter is provided', fakeAsync(() => {

--- a/projects/ngx-testbox/src/__tests__/run-tasks-until-stable.spec.ts
+++ b/projects/ngx-testbox/src/__tests__/run-tasks-until-stable.spec.ts
@@ -138,6 +138,7 @@ describe('runTasksUntilStable', () => {
     }));
 
     it('should restore original setInterval after completion', fakeAsync(() => {
+      fixture = TestBed.createComponent(TestComponent);
       const originalSetInterval = window.setInterval;
 
       runTasksUntilStable(fixture);

--- a/projects/ngx-testbox/src/__tests__/run-tasks-until-stable.spec.ts
+++ b/projects/ngx-testbox/src/__tests__/run-tasks-until-stable.spec.ts
@@ -33,8 +33,18 @@ class TestComponent implements OnInit {
     }
   }
 
-  makeHttpRequest(nextCb?: () => void) {
-    return this.httpClient.get('/api/test').subscribe(nextCb);
+  makeHttpRequest(nextCb?: (...args: any[]) => void, secondCb?: (...args: any[]) => void, thirdCb?: (...args: any[]) => {}) {
+    return this.httpClient.get('/api/test').subscribe((data) => {
+      nextCb?.(data);
+
+      this.httpClient.get('/api/second').subscribe((data2) => {
+        secondCb?.(data2);
+
+        this.httpClient.get('/api/third').subscribe((data3) => {
+          thirdCb?.(data3);
+        })
+      })
+    });
   }
 
   runIntervalOutsideAngular() {
@@ -69,19 +79,25 @@ describe('runTasksUntilStable', () => {
   });
 
   describe('HTTP handling', () => {
-    it('should complete HTTP calls with provided instructions', fakeAsync(() => {
+    it('should complete all subsequent HTTP calls with provided instructions', fakeAsync(() => {
       const httpCallInstructions: HttpCallInstruction[] = [
-        [['/api/test', 'GET'], () => new HttpResponse({body: {data: 'test'}, status: 200})]
+        [['/api/test', 'GET'], () => new HttpResponse({body: {data: 'test'}, status: 200})],
+        [['/api/second', 'GET'], () => new HttpResponse({body: {data: 'test2'}, status: 200})],
+        [['/api/third', 'GET'], () => new HttpResponse({body: {data: 'test3'}, status: 200})]
       ];
       const nextCbSpy = jasmine.createSpy().and.callThrough();
+      const nextCbSpy2 = jasmine.createSpy().and.callThrough();
+      const nextCbSpy3 = jasmine.createSpy().and.callThrough();
 
       initComponent();
 
-      component.makeHttpRequest(nextCbSpy);
+      component.makeHttpRequest(nextCbSpy, nextCbSpy2, nextCbSpy3);
 
       runTasksUntilStable(fixture, {httpCallInstructions});
 
       expect(nextCbSpy).toHaveBeenCalledWith({data: 'test'});
+      expect(nextCbSpy2).toHaveBeenCalledWith({data: 'test2'});
+      expect(nextCbSpy3).toHaveBeenCalledWith({data: 'test3'});
     }));
 
     it('should throw an error if an HTTP instruction is not invoked', fakeAsync(() => {

--- a/projects/ngx-testbox/src/__tests__/run-tasks-until-stable.spec.ts
+++ b/projects/ngx-testbox/src/__tests__/run-tasks-until-stable.spec.ts
@@ -27,9 +27,9 @@ class TestComponent implements OnInit {
 
   ngOnInit() {
     if (this.isTestingIntervalWithinZone) {
-      this.runIntervalInsideAngular()
+      this.runIntervalInsideAngular();
     } else {
-      this.runIntervalOutsideAngular()
+      this.runIntervalOutsideAngular();
     }
   }
 
@@ -129,7 +129,8 @@ describe('runTasksUntilStable', () => {
 
       try {
         runTasksUntilStable(fixture);
-      } catch (error) {}
+      } catch (error) {
+      }
 
       expect(consoleWarnSpy).toHaveBeenCalled();
       expect(consoleWarnSpy.calls.mostRecent().args[0]).toContain('setInterval detected during runTasksUntilStable execution');

--- a/projects/ngx-testbox/testing/src/complete-http-calls.ts
+++ b/projects/ngx-testbox/testing/src/complete-http-calls.ts
@@ -59,6 +59,7 @@ export const getRequestsFromQueue = (httpTestingController = TestBed.inject(Http
  * @param httpCallInstructions - An array of instructions defining how to handle specific HTTP requests
  * @param options - Optional configuration options
  * @param options.httpTestingController - The HTTP testing controller instance (defaults to the one from TestBed)
+ * @param options.testRequests - The HTTP requests to be handled. If not provided, it will use the queue from the testing controller.
  * @throws Error if no matching instruction is found for a request
  */
 export const completeHttpCalls = (httpCallInstructions: HttpCallInstruction[], {

--- a/projects/ngx-testbox/testing/src/complete-http-calls.ts
+++ b/projects/ngx-testbox/testing/src/complete-http-calls.ts
@@ -62,11 +62,13 @@ export const getRequestsFromQueue = (httpTestingController = TestBed.inject(Http
  * @throws Error if no matching instruction is found for a request
  */
 export const completeHttpCalls = (httpCallInstructions: HttpCallInstruction[], {
-  httpTestingController = TestBed.inject(HttpTestingController)
+  httpTestingController = TestBed.inject(HttpTestingController),
+  testRequests
 }: {
   httpTestingController?: HttpTestingController;
+  testRequests?: TestRequest[];
 } = {}) => {
-  const requests = getRequestsFromQueue(httpTestingController);
+  const requests = testRequests || getRequestsFromQueue(httpTestingController);
 
   for (let testRequest of requests) {
     if (testRequest.cancelled) {

--- a/projects/ngx-testbox/testing/src/run-tasks-until-stable.ts
+++ b/projects/ngx-testbox/testing/src/run-tasks-until-stable.ts
@@ -92,7 +92,7 @@ export const MAXIMUM_ATTEMPTS = 30;
  */
 export const runTasksUntilStable = (fixture: ComponentFixture<unknown>, {
   iterationMs,
-  httpCallInstructions
+  httpCallInstructions = []
 }: RunTasksUntilStableParams = {}) => {
   const rollbackOriginalSetInterval = patchSetInterval();
 
@@ -109,17 +109,14 @@ export const runTasksUntilStable = (fixture: ComponentFixture<unknown>, {
 
     fixture.detectChanges();
     passTime(iterationMs);
-
-    if (requiredHttpCallInstructions) {
-      completeHttpCalls(requiredHttpCallInstructions);
-      fixture.detectChanges();
-      try {
-        passTime(iterationMs);
-      } catch (error) {
-        // We need the catch in cases when http instruction responds with an error, and the error callback is not passed to the observer. Otherwise, the error will fail the runtime.
-        if (!(error instanceof HttpErrorResponse)) {
-          throw error;
-        }
+    completeHttpCalls(requiredHttpCallInstructions, {testRequests: requests});
+    fixture.detectChanges();
+    try {
+      passTime(iterationMs);
+    } catch (error) {
+      // We need the catch in cases when http instruction responds with an error, and the error callback is not passed to the observer. Otherwise, the error will fail the runtime.
+      if (!(error instanceof HttpErrorResponse)) {
+        throw error;
       }
     }
   }


### PR DESCRIPTION
Changed
* `runTasksUntilStable` - PATCH now always tries to complete all pending HTTP requests, even if HTTP call instructions are not provided.
* `completeHttpCalls` - MINOR accepts optional field in the options object parameter - `testRequests`.

Fixed
* `runTasksUntilStable` - PATCH for the Angular version 17th and earlier ones.
The issue was the fixture is still stable despite pending HTTP requests in the queue.